### PR TITLE
AD-805: fix: include enrolstartdate to the enrolment event

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -47,6 +47,9 @@ class enrol_coursecompleted_observer {
                 if ($DB->record_exists('role', ['id' => $enrol->roleid])) {
                     // Invalid courses are already detected when context is calculated.
                     if ($DB->record_exists('course', ['id' => $enrol->courseid])) {
+                        if (empty($enrol->enrolstartdate)) {
+                            $enrol->enrolstartdate = $event->timecreated;
+                        }
                         if ($enrol->enrolperiod > 0) {
                             $enrol->enrolenddate = max(time(), $enrol->enrolstartdate) + $enrol->enrolperiod;
                         }

--- a/version.php
+++ b/version.php
@@ -28,5 +28,5 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->requires = 2022041900;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->component = 'enrol_coursecompleted';
-$plugin->release = 'v4.1.2';
+$plugin->release = 'v4.1.3';
 $plugin->version = 2025013101;


### PR DESCRIPTION
This adds the enrol starting date when enrolling the user on course_completed event.